### PR TITLE
Bebop 2 toolchain

### DIFF
--- a/toolchains/bebop2-toolchain.cmake
+++ b/toolchains/bebop2-toolchain.cmake
@@ -1,0 +1,16 @@
+set(PLATFORM Bebop)
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_SYSTEM_PROCESSOR arm)
+
+# Specify the cross compiler
+SET(CMAKE_C_COMPILER   /opt/arm-2016.02-linaro/bin/arm-linux-gnueabihf-gcc)
+SET(CMAKE_CXX_COMPILER /opt/arm-2016.02-linaro/bin/arm-linux-gnueabihf-g++)
+
+# Where is the target environment
+SET(CMAKE_FIND_ROOT_PATH  /opt/arm-2016.02-linaro/arm-linux-gnueabihf/libc)
+
+# Search for programs in the build host directories
+SET(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+SET(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+SET(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+set(CMAKE_MODULE_PATH "${CMAKE_FIND_ROOT_PATH}/")

--- a/tuv_lib/CMakeLists.txt
+++ b/tuv_lib/CMakeLists.txt
@@ -61,7 +61,6 @@ file(REMOVE "include/tuv/tuv.h")
 file(GLOB_RECURSE HDRS_INC RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}/include"  "include/*.h")
 
 foreach(filename ${HDRS_INC})
-    message(${filename})
     if ("tuv/encoding/encoder_jpeg.h" STREQUAL ${filename} AND NOT ${JPEG_FOUND})
     else()
         file(APPEND "include/tuv/tuv.h" "#include <${filename}>\r\n")

--- a/tuv_lib/CMakeLists.txt
+++ b/tuv_lib/CMakeLists.txt
@@ -61,7 +61,11 @@ file(REMOVE "include/tuv/tuv.h")
 file(GLOB_RECURSE HDRS_INC RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}/include"  "include/*.h")
 
 foreach(filename ${HDRS_INC})
-    file(APPEND "include/tuv/tuv.h" "#include <${filename}>\r\n")
+    message(${filename})
+    if ("tuv/encoding/encoder_jpeg.h" STREQUAL ${filename} AND NOT ${JPEG_FOUND})
+    else()
+        file(APPEND "include/tuv/tuv.h" "#include <${filename}>\r\n")
+    endif()
 endforeach(filename)
 
 # Add headers target for Qt


### PR DESCRIPTION
Using `arm-2016.03-linaro` instead of `arm-2012.02`

Also excluded a jpeg header when jpeg is not found. Otherwise it won't compile.